### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Definition of code OWNERS for the openconfig/security-services repository.
+#
+# default approvers:
+* @openconfig/security-services-approvers


### PR DESCRIPTION
Reference to the approvers team:
https://github.com/orgs/openconfig/teams/security-services-approvers/members