### PR TITLE
CDXToSPDX: Mapping Package Supplier, DownloadLocation, Contain Relationships

### DIFF
--- a/cli/cmd/sbom/sbom.go
+++ b/cli/cmd/sbom/sbom.go
@@ -124,9 +124,10 @@ func AddCycloneDXComponent(
 
 	if IsComponentSPDXPackage(c) {
 		p := &spdx.Package{
-			PackageName:        c.Name,
-			PackageVersion:     c.Version,
-			PackageDescription: c.Description,
+			PackageSPDXIdentifier: toSPDXElementID(c.BOMRef),
+			PackageName:           c.Name,
+			PackageVersion:        c.Version,
+			PackageDescription:    c.Description,
 		}
 		validIdentifier := false
 		if c.PackageURL != "" {
@@ -148,6 +149,27 @@ func AddCycloneDXComponent(
 		if !validIdentifier {
 			log.Warningf("package %q:%q:%q missing PURL and CPE", c.Name, c.Type, c.MIMEType)
 		}
+
+		// Add supplier information.
+		if c.Supplier != nil {
+			p.PackageSupplier = &common.Supplier{
+				Supplier:     c.Supplier.Name,
+				SupplierType: "NOASSERTION",
+			}
+		}
+
+		// Add package download location.
+		if c.ExternalReferences != nil {
+			for _, eRef := range *c.ExternalReferences {
+				if eRef.Type == cdx.ERTypeDistribution {
+					p.PackageDownloadLocation = eRef.URL
+				}
+			}
+		}
+		if p.PackageDownloadLocation == "" {
+			p.PackageDownloadLocation = "NOASSERTION"
+		}
+
 		spdxDoc.Packages = append(spdxDoc.Packages, p)
 	}
 
@@ -158,10 +180,28 @@ func AddCycloneDXComponent(
 			if err != nil {
 				return fmt.Errorf("failed to add sub-component %q: %w", subComponent.BOMRef, err)
 			}
+			// Add sub-components as "CONTAINS" relationships.
+			spdxDoc.Relationships = append(spdxDoc.Relationships, &v2_3.Relationship{
+				RefA:         toSPDXDocElementID(c.BOMRef),
+				RefB:         toSPDXDocElementID(subComponent.BOMRef),
+				Relationship: "CONTAINS",
+			})
 		}
 	}
 
 	return nil
+}
+
+// ========== Helper methods =============
+
+func toSPDXDocElementID(bomRef string) common.DocElementID {
+	return common.DocElementID{
+		ElementRefID: toSPDXElementID(bomRef),
+	}
+}
+
+func toSPDXElementID(bomRef string) common.ElementID {
+	return common.ElementID(fmt.Sprintf("SPDXRef-%s", bomRef))
 }
 
 func IsComponentSPDXPackage(component cdx.Component) bool {

--- a/cli/cmd/sbom/sbom_test.go
+++ b/cli/cmd/sbom/sbom_test.go
@@ -126,4 +126,126 @@ func TestAddCycloneDXComponents(t *testing.T) {
 			t.Errorf("Expected 2 external references, got %d", len(pkg.PackageExternalReferences))
 		}
 	})
+
+	t.Run("Test component with supplier information", func(t *testing.T) {
+		refMap := make(map[string]cdx.Component)
+		typeMap := make(map[string]int)
+		spdxDoc := &spdx.Document{}
+
+		emptyComponents := &[]cdx.Component{}
+		component := cdx.Component{
+			BOMRef: "test-ref",
+			Type:   cdx.ComponentTypeLibrary,
+			Name:   "test-component",
+			Supplier: &cdx.OrganizationalEntity{
+				Name: "test-supplier",
+			},
+			Components: emptyComponents,
+		}
+
+		err := AddCycloneDXComponent(component, refMap, typeMap, spdxDoc)
+
+		if err != nil {
+			t.Errorf("AddCycloneDXComponents() error = %v, want nil", err)
+		}
+
+		if len(spdxDoc.Packages) != 1 {
+			t.Fatalf("Expected 1 package, got %d", len(spdxDoc.Packages))
+		}
+
+		// Check package supplier information.
+		pkg := spdxDoc.Packages[0]
+		if pkg.PackageSupplier == nil {
+			t.Fatalf("Package supplier must be set")
+		}
+
+		if pkg.PackageSupplier.Supplier != component.Supplier.Name {
+			t.Fatalf("Expected package supplier to be %q, got %q",
+				component.Supplier.Name, pkg.PackageSupplier.Supplier)
+		}
+
+		if pkg.PackageSupplier.SupplierType != "NOASSERTION" {
+			t.Fatalf("Expected package supplier type to be NOASSERTION, got %q",
+				pkg.PackageSupplier.SupplierType)
+		}
+	})
+
+	t.Run("Test component with download location", func(t *testing.T) {
+		refMap := make(map[string]cdx.Component)
+		typeMap := make(map[string]int)
+		spdxDoc := &spdx.Document{}
+		pkgDownloadLocation := "http://downlaodlink"
+		emptyComponents := &[]cdx.Component{}
+		component := cdx.Component{
+			BOMRef: "test-ref",
+			Type:   cdx.ComponentTypeLibrary,
+			Name:   "test-component",
+			ExternalReferences: &[]cdx.ExternalReference{
+				{
+					Type: cdx.ERTypeDistribution,
+					URL:  pkgDownloadLocation,
+				},
+			},
+			Components: emptyComponents,
+		}
+
+		err := AddCycloneDXComponent(component, refMap, typeMap, spdxDoc)
+
+		if err != nil {
+			t.Errorf("AddCycloneDXComponents() error = %v, want nil", err)
+		}
+
+		// Check package supplier information.
+		pkg := spdxDoc.Packages[0]
+		if pkg.PackageDownloadLocation != pkgDownloadLocation {
+			t.Fatalf("Expected package supplier to be %s, got %s",
+				pkgDownloadLocation, pkg.PackageDownloadLocation)
+		}
+	})
+
+	t.Run("Test component with contain relationships", func(t *testing.T) {
+		refMap := make(map[string]cdx.Component)
+		typeMap := make(map[string]int)
+		spdxDoc := &spdx.Document{}
+		refA := "test-refA"
+		refB := "test-refB"
+		component := cdx.Component{
+			BOMRef: refA,
+			Type:   cdx.ComponentTypeLibrary,
+			Name:   "test-componentA",
+			Components: &[]cdx.Component{
+				{
+					BOMRef: refB,
+					Type:   cdx.ComponentTypeLibrary,
+					Name:   "test-componentB",
+				},
+			},
+		}
+
+		err := AddCycloneDXComponent(component, refMap, typeMap, spdxDoc)
+		if err != nil {
+			t.Errorf("AddCycloneDXComponents() error = %v, want nil", err)
+		}
+
+		// Check contain relationship.
+		if len(spdxDoc.Packages) != 2 {
+			t.Fatalf("Expected 2 package, got %d", len(spdxDoc.Packages))
+		}
+
+		relations := spdxDoc.Relationships
+		if len(relations) != 1 {
+			t.Fatalf("Expected 1 relationship, got %d", len(relations))
+		}
+
+		relation := relations[0]
+		if relation.Relationship != "CONTAINS" {
+			t.Fatalf("Expected relationship of type CONTAINS, got %q", relation.Relationship)
+		}
+		if relation.RefA != toSPDXDocElementID(refA) {
+			t.Fatalf("Expected relation.refA to be %q, got %q", toSPDXElementID(refA), relation.RefA)
+		}
+		if relation.RefB != toSPDXDocElementID(refB) {
+			t.Fatalf("Expected relation.refB to be %q, got %q", toSPDXElementID(refB), relation.RefB)
+		}
+	})
 }


### PR DESCRIPTION
This PR introduces the following changes:

1. **`toSPDXElementID` helper method**: to map `CycloneDX Bom-Ref` to `SPDXElementID`.
2. **`toSPDXDocElementID ` helper method:** to map `CycloneDX Bom-Ref` to `SPDXDocElementID`, SPDX uses `SPDXDocElementID` in relationships.
3. **SPDX Package Supplier Mapping**: Logic to map CycloneDX component supplier information to SPDX package supplier fields. Since CycloneDX does not specify the supplier type, it is set to "NOASSERTION" in the corresponding SPDX mappings.
4. **SPDX Package Download Location Mapping**: CycloneDX does not have a dedicated field for specifying a component's download location. However, external references of type "distribution" (as per [CycloneDX 1.6 spec](https://cyclonedx.org/docs/1.6/json/#components_items_externalReferences_items_type)) can be used for this purpose. This logic first checks for a distribution-type external reference; if none is found, the corresponding SPDX field is set to "NOASSERTION".
5. **"CONTAINS" Relationship Mapping**: CycloneDX expresses contain relationship between components using nested components ([CDX component assemblies](https://cyclonedx.org/use-cases/component-assemblies/)). This PR maps those relationships to SPDX "CONTAINS" relationships.