### PR TITLE
Platform Configuration Registers Open Config Standard based proto definitions for External Vendors

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,25 @@ SBOM are used to convey the software manifest of a package including a dependenc
 ```shell
 ./sbom_cli convert ./cyclonedx.json ./spdx.json --format=cyclonedx-v16-proto --validate
 ```
+
+### PCRService
+
+### Overview
+The GetPCR RPC provides a standardized gRPC interface for retrieving Platform Configuration Register (PCR) values from vendors. This service is essential for establishing a "Golden" reference of measurements used in remote attestation and verified boot processes.
+
+PCR values represent the state of a device's boot chain, from the initial Root of Trust through the kernel and container layers. By providing a common proto definition, this service allows network operators to query expected PCR measurements across different hardware models and software versions, ensuring that the device's integrity can be validated against a known-good baseline.
+
+### Key Components
+
+### Integrity Measurement: 
+Supports both TPM 1.2 and TPM 2.0 PCR banks, covering various stages of the boot process defined in the BootStage enumeration (e.g., BIOS, Boot Loader, Kernel).
+
+### Flexible Querying: 
+Users can retrieve specific PCR sets based on a combination of hardware models, software/firmware image versions, and preferred hash algorithms (SHA256, SHA512, etc.).
+
+### Discovery RPCs: 
+Includes helper methods to fetch lists of supported hardware models, bootloader versions, and software versions available in the vendor's database.
+
+
+
+

--- a/proto/pcr.proto
+++ b/proto/pcr.proto
@@ -1,34 +1,131 @@
-import google.
+// Copyright 2023 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" B1IS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+syntax = "proto3";
 
+package openconfig.pcrservice;
+
+import "github.com/openconfig/attestz/proto/common_definitions.proto";
+
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/openconfig/pcrservice";
+
+
+// Enumerations
+enum HashAlgo {
+  HASH_ALGO_UNSPECIFIED = 0;
+  HASH_ALGO_SHA1 = 1;
+  HASH_ALGO_SHA256 = 2;
+  HASH_ALGO_SHA384 = 3;
+  HASH_ALGO_SHA512 = 4;
+}
+
+enum RootOfTrustMeasurement {
+   UNSPECIFIED = 0;
+   TPM_1.2_PCR = 1;
+   TPM_2.0_PCR = 2;
+}
+
+enum BootStage {
+SRTM = 0;
+BIOS = 1;
+BIOS_CONFIGURATION = 2;
+EMBEDDED_OPTION_ROMS = 3;
+PLATFORM_EXTENSIONS = 4;
+PLATFORM_INITIALIZATION_DRIVERS = 5;
+PLATFORM_CONFIGURATIONS = 6;
+UEFI_APPLICATIONS = 7;
+UEFI_APPLICATION_CONFIGURATION = 8;
+PARTITION_TABLE = 9;
+BOOT_MANAGER = 10;
+BOOT_CONFIGURATION = 11; // Includes critical boot security configuration such as secure boot.
+BOOT_LOADER = 12;
+KERNEL_CONFIGURATION = 13;
+KERNEL_COMMAND_LINE = 14;
+KERNEL = 15;
+OS_CONFIGURATION = 16;
+ROOT_FILESYSTEM = 17;
+OS_EXTENSION = 18;
+CONTAINER_IMAGES = 19;
+OTHER = 20;
+}
 message PcrValues { 
    int32 pcr_index = 1; // Refers to the PCR index value
-   string pcr_name = 2; // Refers to a quick reference name to define PCR measurement content associated with the pcr index. eg - UEFI Boot Manager Code=pcr_4
-   bytes pcr_value = 3; // Refers to set of PCR raw bytes
+   repeated BootStage boot_stage = 2; // Refers to a quick reference name to define PCR measurement content associated with the pcr index. eg - UEFI Boot Manager Code=pcr_4
+   bytes pcr_values = 3; // Refers to set of PCR raw bytes
 }
 
-message DevicePcrCollection { 
-   string software_version = 1; // Refers to the software version of the current ISO image
-   TpmVersion tpm_version = 2; // Refers to the TPM (Trusted Platform Module) version supported by each Control Card
-   string hardware_model = 3; // Refers to hardware model for the collected PCR
-   google.protobuf.Timestamp timestamp = 4; // Time of PCR Artifact Collection
-   Tpm20HashAlgo hash_algorithm = 5; // Hash algorithm of the selected PCR bank. 
-   map<int32, PcrValues> pcr_values = 6; // 
+// Get RPC Messages
+message GetRequest { 
+   string image_version = 1; // Refers to the the version of the software/firmware
+   string hardware_model = 2; // Refers to hardware model for the collected PCR
+   string HashAlgo hash_algorithm = 4; // Hash algorithm of the selected PCR bank.
+   }
+
+message GetResponse { 
+   string image_version = 1; // Refers to the the version of the software/firmware
+   string hardware_model = 2; // Refers to hardware model for the collected PCR
+   string HashAlgo hash_algorithm = 4; // Hash algorithm of the selected PCR bank.
+   RootOfTrustMeasurement measurement = 1; // Refers to the TPM (Trusted Platform Module) version supported by each Control Card
+   google.protobuf.Timestamp timestamp = 2; // Time of PCR Artifact Collection
+   map<int32, PcrValues> pcr_values = 4; // 
 }
 
-enum Tpm20HashAlgo {
-  TPM20HASH_ALGO_UNSPECIFIED = 0;
-  TPM20HASH_ALGO_SHA1 = 1;
-  TPM20HASH_ALGO_SHA256 = 2;
-  TPM20HASH_ALGO_SHA384 = 3;
-  TPM20HASH_ALGO_SHA512 = 4;
+// Fetch RPC Messages
+
+// Request for fetching all known hardware models.
+message FetchHardwareModelsRequest {}
+
+// Response containing a list of known hardware model strings.
+message FetchHardwareModelsResponse {
+    repeated string hardware_models = 1; // List of valid hardware model strings (e.g., "A9K-400-LC", "Nokia-7750")
 }
 
-enum TpmVersion {
-   TPM_VERSION_UNSPECIFIED = 0;
-   TPM_VERSION_1.2 = 1;
-   TPM_VERSION_2.0 = 2;
+// Request for fetching all known bootloader versions for a specific hardware model.
+message FetchBootLoaderVersionsRequest {
+    string hardware_model = 1; // The hardware model to fetch bootloader versions for.
 }
 
-service PCRService {
+// Response containing a list of known bootloader version strings.
+message FetchBootLoaderVersionsResponse {
+    repeated string bootloader_versions = 1; // List of valid bootloader version strings for the specified hardware model.
+}
 
-   rpc Get(GetRequest) returns (GetResponse);
+// Request for fetching all known software versions for a specific hardware model.
+message FetchSoftwareVersionsRequest {
+    string hardware_model = 1; // The hardware model to fetch software versions for.
+}
+
+// Response containing a list of known software version strings.
+message FetchSoftwareVersionsResponse {
+    repeated string software_versions = 1; // List of valid software version strings (e.g., "7.5.1", "XR-7.1.2") for the specified hardware model.
+}
+
+
+// Service Definition with RPCs
+service SecurityService {
+
+   // Retrieves the PCR values for a specific software/hardware/bootloader combination.
+   rpc GetPCR(GetRequest) returns (GetResponse);
+
+   // Fetches a list of all known hardware model strings supported by the vendor service.
+   rpc FetchHardwareModels(FetchHardwareModelsRequest) returns (FetchHardwareModelsResponse);
+
+   // Fetches a list of known bootloader version strings for a given hardware model.
+   rpc FetchBootLoaderVersions(FetchBootLoaderVersionsRequest) returns (FetchBootLoaderVersionsResponse);
+
+   // Fetches a list of known software version strings for a given hardware model.
+   rpc FetchSoftwareVersions(FetchSoftwareVersionsRequest) returns (FetchSoftwareVersionsResponse);
+}

--- a/proto/pcr.proto
+++ b/proto/pcr.proto
@@ -32,7 +32,7 @@ enum HashAlgo {
   HASH_ALGO_SHA512 = 4;
 }
 
-enum RootOfTrustMeasurement {
+enum RootOfTrustForMeasurement {
    UNSPECIFIED = 0;
    TPM_1.2_PCR = 1;
    TPM_2.0_PCR = 2;
@@ -77,8 +77,8 @@ message GetRequest {
 message GetResponse { 
    string image_version = 1; // Refers to the the version of the software/firmware
    string hardware_model = 2; // Refers to hardware model for the collected PCR
-   string HashAlgo hash_algorithm = 4; // Hash algorithm of the selected PCR bank.
-   RootOfTrustMeasurement measurement = 1; // Refers to the TPM (Trusted Platform Module) version supported by each Control Card
+   HashAlgo hash_algorithm = 4; // Hash algorithm of the selected PCR bank.
+   RootOfTrustMeasurement root_of_trust = 1; // Refers to the TPM (Trusted Platform Module) version supported by each Control Card
    google.protobuf.Timestamp timestamp = 2; // Time of PCR Artifact Collection
    map<int32, PcrValues> pcr_values = 4; // 
 }

--- a/proto/pcr.proto
+++ b/proto/pcr.proto
@@ -1,0 +1,34 @@
+import google.
+
+message PcrValues { 
+   int32 pcr_index = 1; // Refers to the PCR index value
+   string pcr_name = 2; // Refers to a quick reference name to define PCR measurement content associated with the pcr index. eg - UEFI Boot Manager Code=pcr_4
+   bytes pcr_value = 3; // Refers to set of PCR raw bytes
+}
+
+message DevicePcrCollection { 
+   string software_version = 1; // Refers to the software version of the current ISO image
+   TpmVersion tpm_version = 2; // Refers to the TPM (Trusted Platform Module) version supported by each Control Card
+   string hardware_model = 3; // Refers to hardware model for the collected PCR
+   google.protobuf.Timestamp timestamp = 4; // Time of PCR Artifact Collection
+   Tpm20HashAlgo hash_algorithm = 5; // Hash algorithm of the selected PCR bank. 
+   map<int32, PcrValues> pcr_values = 6; // 
+}
+
+enum Tpm20HashAlgo {
+  TPM20HASH_ALGO_UNSPECIFIED = 0;
+  TPM20HASH_ALGO_SHA1 = 1;
+  TPM20HASH_ALGO_SHA256 = 2;
+  TPM20HASH_ALGO_SHA384 = 3;
+  TPM20HASH_ALGO_SHA512 = 4;
+}
+
+enum TpmVersion {
+   TPM_VERSION_UNSPECIFIED = 0;
+   TPM_VERSION_1.2 = 1;
+   TPM_VERSION_2.0 = 2;
+}
+
+service PCRService {
+
+   rpc Get(GetRequest) returns (GetResponse);

--- a/proto/pcr.proto
+++ b/proto/pcr.proto
@@ -35,7 +35,7 @@ enum HashAlgo {
 }
 
 enum RootOfTrustVersion {
-   UNSPECIFIED = 0;
+   ROOT_OF_TRUST_VERSION_UNSPECIFIED = 0;
    TPM_1.2_PCR = 1;
    TPM_2.0_PCR = 2;
 }
@@ -64,16 +64,29 @@ CONTAINER_IMAGES = 19;
 OTHER = 20;
 }
 message PcrValues { 
-   int32 pcr_index = 1; // Refers to the PCR index value
-   repeated BootStage boot_stage = 2; // Refers to a quick reference name to define PCR measurement content associated with the pcr index. eg - UEFI Boot Manager Code=pcr_4
-   repeated bytes pcr_values = 3; // Refers to set of PCR raw bytes
+   // Refers to the PCR index value
+   int32 pcr_index = 1; 
+
+   // Refers to a quick reference name to define PCR measurement content 
+   // associated with the pcr index. eg - UEFI Boot Manager Code=pcr_4
+   repeated BootStage boot_stage = 2; 
+
+   // Refers to the set of multiple PCR raw byte hashes for this index.
+   repeated bytes hashes = 3; 
 }
 
 message MeasurementIdentifier {
-    string image_version = 1; // Refers to the the version of the software/firmware
-    string bootloader_version = 2; // Refers to aboot version or bootloader versions for vendors
-    string hardware_model = 3; // Refers to hardware model for the collected PCR
-    HashAlgo hash_algorithm = 4; // Hash algorithm of the selected PCR bank.
+    // Refers to the the version of the software/firmware
+    string image_version = 1; 
+
+    // Refers to aboot version or bootloader versions for vendors
+    string bootloader_version = 2; 
+
+    // Refers to hardware model for the collected PCR
+    string hardware_model = 3; 
+
+    // Hash algorithm of the selected PCR bank
+    HashAlgo hash_algorithm = 4; 
 }
 
 // Get RPC Messages
@@ -83,10 +96,17 @@ message GetRequest {
 
 message GetResponse { 
    MeasurementIdentifier identifier = 1;
-   RootOfTrustVersion root_of_trust = 2; // Refers to the TPM (Trusted Platform Module) version supported by each Control Card
-   google.protobuf.Timestamp timestamp = 3; // Time of PCR Artifact Collection
-   google.type.Date calendar_date = 4; // Date of PCR Artifact Collection
-   map<int32, PcrValues> pcr_values = 5; // 
+
+   // Refers to the TPM (Trusted Platform Module) version supported by each Control Card
+   RootOfTrustVersion root_of_trust = 2; 
+ 
+   // Time of PCR Artifact Collection
+   google.protobuf.Timestamp timestamp = 3;
+
+   // Date of PCR Artifact Collection
+   google.type.Date calendar_date = 4;
+
+   map<int32, PcrValues> pcr_values = 5; 
 }
 
 // Fetch RPC Messages
@@ -96,27 +116,34 @@ message FetchHardwareModelsRequest {}
 
 // Response containing a list of known hardware model strings.
 message FetchHardwareModelsResponse {
-    repeated string hardware_models = 1; // List of valid hardware model strings (e.g., "A9K-400-LC", "Nokia-7750")
+    // List of valid hardware model strings (e.g., "A9K-400-LC", "Nokia-7750")
+    repeated string hardware_models = 1;
 }
 
 // Request for fetching all known bootloader versions for a specific hardware model.
 message FetchBootLoaderVersionsRequest {
-    string hardware_model = 1; // The hardware model to fetch bootloader versions for.
+    // The hardware model to fetch bootloader versions
+    string hardware_model = 1; 
 }
 
 // Response containing a list of known bootloader version strings.
 message FetchBootLoaderVersionsResponse {
-    repeated string bootloader_versions = 1; // List of valid bootloader version strings for the specified hardware model.
+    // List of valid bootloader version strings for the specified hardware model
+    repeated string bootloader_versions = 1; 
 }
 
 // Request for fetching all known software versions for a specific hardware model.
 message FetchSoftwareVersionsRequest {
-    string hardware_model = 1; // The hardware model to fetch software versions for.
+    // The hardware model to fetch software versions
+    string hardware_model = 1; 
 }
 
 // Response containing a list of known software version strings.
 message FetchSoftwareVersionsResponse {
-    repeated string software_versions = 1; // List of valid software version strings (e.g., "7.5.1", "XR-7.1.2") for the specified hardware model.
+
+    // List of valid software version strings 
+    // (e.g., "7.5.1", "XR-7.1.2") for the specified hardware model
+    repeated string software_versions = 1; 
 }
 
 

--- a/proto/pcr.proto
+++ b/proto/pcr.proto
@@ -20,6 +20,8 @@ import "github.com/openconfig/attestz/proto/common_definitions.proto";
 
 import "google/protobuf/timestamp.proto";
 
+import "google/type/date.proto";
+
 option go_package = "github.com/openconfig/pcrservice";
 
 
@@ -32,7 +34,7 @@ enum HashAlgo {
   HASH_ALGO_SHA512 = 4;
 }
 
-enum RootOfTrustForMeasurement {
+enum RootOfTrustVersion {
    UNSPECIFIED = 0;
    TPM_1.2_PCR = 1;
    TPM_2.0_PCR = 2;
@@ -64,23 +66,27 @@ OTHER = 20;
 message PcrValues { 
    int32 pcr_index = 1; // Refers to the PCR index value
    repeated BootStage boot_stage = 2; // Refers to a quick reference name to define PCR measurement content associated with the pcr index. eg - UEFI Boot Manager Code=pcr_4
-   bytes pcr_values = 3; // Refers to set of PCR raw bytes
+   repeated bytes pcr_values = 3; // Refers to set of PCR raw bytes
+}
+
+message MeasurementIdentifier {
+    string image_version = 1; // Refers to the the version of the software/firmware
+    string bootloader_version = 2; // Refers to aboot version or bootloader versions for vendors
+    string hardware_model = 3; // Refers to hardware model for the collected PCR
+    HashAlgo hash_algorithm = 4; // Hash algorithm of the selected PCR bank.
 }
 
 // Get RPC Messages
 message GetRequest { 
-   string image_version = 1; // Refers to the the version of the software/firmware
-   string hardware_model = 2; // Refers to hardware model for the collected PCR
-   string HashAlgo hash_algorithm = 4; // Hash algorithm of the selected PCR bank.
+   MeasurementIdentifier identifier = 1;
    }
 
 message GetResponse { 
-   string image_version = 1; // Refers to the the version of the software/firmware
-   string hardware_model = 2; // Refers to hardware model for the collected PCR
-   HashAlgo hash_algorithm = 4; // Hash algorithm of the selected PCR bank.
-   RootOfTrustMeasurement root_of_trust = 1; // Refers to the TPM (Trusted Platform Module) version supported by each Control Card
-   google.protobuf.Timestamp timestamp = 2; // Time of PCR Artifact Collection
-   map<int32, PcrValues> pcr_values = 4; // 
+   MeasurementIdentifier identifier = 1;
+   RootOfTrustVersion root_of_trust = 2; // Refers to the TPM (Trusted Platform Module) version supported by each Control Card
+   google.protobuf.Timestamp timestamp = 3; // Time of PCR Artifact Collection
+   google.type.Date calendar_date = 4; // Date of PCR Artifact Collection
+   map<int32, PcrValues> pcr_values = 5; // 
 }
 
 // Fetch RPC Messages

--- a/proto/pcr.proto
+++ b/proto/pcr.proto
@@ -7,7 +7,7 @@
 //    http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" B1IS,
+// distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
@@ -15,8 +15,6 @@
 syntax = "proto3";
 
 package openconfig.pcrservice;
-
-import "github.com/openconfig/attestz/proto/common_definitions.proto";
 
 import "google/protobuf/timestamp.proto";
 
@@ -36,8 +34,8 @@ enum HashAlgo {
 
 enum RootOfTrustVersion {
    ROOT_OF_TRUST_VERSION_UNSPECIFIED = 0;
-   TPM_1.2_PCR = 1;
-   TPM_2.0_PCR = 2;
+   TPM_1_2_PCR = 1;
+   TPM_2_0_PCR = 2;
 }
 
 enum BootStage {
@@ -90,11 +88,11 @@ message MeasurementIdentifier {
 }
 
 // Get RPC Messages
-message GetRequest { 
+message PCRRequest { 
    MeasurementIdentifier identifier = 1;
    }
 
-message GetResponse { 
+message PCRResponse { 
    MeasurementIdentifier identifier = 1;
 
    // Refers to the TPM (Trusted Platform Module) version supported by each Control Card
@@ -103,10 +101,7 @@ message GetResponse {
    // Time of PCR Artifact Collection
    google.protobuf.Timestamp timestamp = 3;
 
-   // Date of PCR Artifact Collection
-   google.type.Date calendar_date = 4;
-
-   map<int32, PcrValues> pcr_values = 5; 
+   map<int32, PcrValues> pcr_values = 4; 
 }
 
 // Fetch RPC Messages
@@ -151,7 +146,7 @@ message FetchSoftwareVersionsResponse {
 service SecurityService {
 
    // Retrieves the PCR values for a specific software/hardware/bootloader combination.
-   rpc GetPCR(GetRequest) returns (GetResponse);
+   rpc FetchPCR(PCRRequest) returns (PCRResponse);
 
    // Fetches a list of all known hardware model strings supported by the vendor service.
    rpc FetchHardwareModels(FetchHardwareModelsRequest) returns (FetchHardwareModelsResponse);

--- a/proto/pcr.proto
+++ b/proto/pcr.proto
@@ -25,42 +25,79 @@ option go_package = "github.com/openconfig/pcrservice";
 
 // Enumerations
 enum HashAlgo {
+  // Default value. Indicates that no hash algorithm was specified or it is unknown.
   HASH_ALGO_UNSPECIFIED = 0;
+  // SHA-1 algorithm (160-bit).
   HASH_ALGO_SHA1 = 1;
+  // SHA-256 algorithm (256-bit). 
   HASH_ALGO_SHA256 = 2;
+  // SHA-384 algorithm (384-bit).
   HASH_ALGO_SHA384 = 3;
+  // SHA-512 algorithm (512-bit).
   HASH_ALGO_SHA512 = 4;
 }
 
 enum RootOfTrustVersion {
+   // Indicates the TPM version is unknown or not provided.
    ROOT_OF_TRUST_VERSION_UNSPECIFIED = 0;
+   // Represents TPM 1.2 specifications. supports fixed pcr banks.
    TPM_1_2_PCR = 1;
+   // Represents TPM 2.0 specifications. Supports multiple PCR banks.
    TPM_2_0_PCR = 2;
 }
 
 enum BootStage {
-SRTM = 0;
-BIOS = 1;
-BIOS_CONFIGURATION = 2;
-EMBEDDED_OPTION_ROMS = 3;
-PLATFORM_EXTENSIONS = 4;
-PLATFORM_INITIALIZATION_DRIVERS = 5;
-PLATFORM_CONFIGURATIONS = 6;
-UEFI_APPLICATIONS = 7;
-UEFI_APPLICATION_CONFIGURATION = 8;
-PARTITION_TABLE = 9;
-BOOT_MANAGER = 10;
-BOOT_CONFIGURATION = 11; // Includes critical boot security configuration such as secure boot.
-BOOT_LOADER = 12;
-KERNEL_CONFIGURATION = 13;
-KERNEL_COMMAND_LINE = 14;
-KERNEL = 15;
-OS_CONFIGURATION = 16;
-ROOT_FILESYSTEM = 17;
-OS_EXTENSION = 18;
-CONTAINER_IMAGES = 19;
-OTHER = 20;
+  // PCR 0: SRTM, BIOS, and Host Platform Extensions.
+  // Reference: TCG PC Client Spec - Section 2.3.1
+  SRTM = 0;
+  BIOS = 1;
+  PLATFORM_EXTENSIONS = 4;
+
+  // PCR 1: Host Platform Configuration.
+  // Reference: TCG PC Client Spec - Section 2.3.2
+  BIOS_CONFIGURATION = 2;
+
+  // PCR 2: UEFI Option ROM Code.
+  // Reference: TCG PC Client Spec - Section 2.3.3
+  EMBEDDED_OPTION_ROMS = 3;
+
+  // PCR 3: UEFI Option ROM Configuration and Data.
+  // Reference: TCG PC Client Spec - Section 2.3.4
+  PLATFORM_INITIALIZATION_DRIVERS = 5;
+
+  // PCR 4: UEFI Boot Manager Code and Variables.
+  // Reference: TCG PC Client Spec - Section 2.3.5
+  UEFI_APPLICATIONS = 7;
+  BOOT_MANAGER = 10;
+
+  // PCR 5: UEFI Boot Manager Configuration and Data.
+  // Reference: TCG PC Client Spec - Section 2.3.6
+  PLATFORM_CONFIGURATIONS = 6;
+  UEFI_APPLICATION_CONFIGURATION = 8;
+  PARTITION_TABLE = 9;
+
+  // PCR 7: Secure Boot Policy.
+  // Reference: TCG PC Client Spec - Section 2.3.8
+  BOOT_CONFIGURATION = 11;
+
+  // PCR 8-15: Operating System Defined.
+  // Reference: TCG PC Client Spec - Section 2.3.9
+  BOOT_LOADER = 12;
+  KERNEL_CONFIGURATION = 13;
+  KERNEL_COMMAND_LINE = 14;
+  KERNEL = 15;
+  OS_CONFIGURATION = 16;
+  ROOT_FILESYSTEM = 17;
+  OS_EXTENSION = 18;
+  
+  // Application/Orchestration Layer.
+  // Measurements for containerized environments or runtime integrity.
+  CONTAINER_IMAGES = 19;
+  
+  // Catch-all for proprietary or vendor-specific measurements.
+  OTHER = 20;
 }
+
 message PcrValues { 
    // Refers to the PCR index value
    int32 pcr_index = 1; 
@@ -74,7 +111,9 @@ message PcrValues {
 }
 
 message MeasurementIdentifier {
-    // Refers to the the version of the software/firmware
+    // Note - The canonical version string (e.g., "7.5.1"). 
+    // MUST match the version in the associated vendor's provided SBOM's and be 
+    // extractable from the binary's internal signed metadata.
     string image_version = 1; 
 
     // Refers to aboot version or bootloader versions for vendors
@@ -111,7 +150,9 @@ message FetchHardwareModelsRequest {}
 
 // Response containing a list of known hardware model strings.
 message FetchHardwareModelsResponse {
-    // List of valid hardware model strings (e.g., "A9K-400-LC", "Nokia-7750")
+    // List of valid hardware model strings.
+    // Values MUST be prefixed with the manufacturer name to ensure uniqueness.
+    // format: "[manufacturer]:[model]"
     repeated string hardware_models = 1;
 }
 
@@ -119,6 +160,10 @@ message FetchHardwareModelsResponse {
 message FetchBootLoaderVersionsRequest {
     // The hardware model to fetch bootloader versions
     string hardware_model = 1; 
+    // Note - The canonical version string (e.g., "7.5.1"). 
+    // MUST match the version in the associated vendor's provided SBOM's and be 
+    // extractable from the binary's internal signed metadata.
+    string image_version = 2;
 }
 
 // Response containing a list of known bootloader version strings.
@@ -129,16 +174,33 @@ message FetchBootLoaderVersionsResponse {
 
 // Request for fetching all known software versions for a specific hardware model.
 message FetchSoftwareVersionsRequest {
-    // The hardware model to fetch software versions
+    // The hardware model to fetch software versions.
+    // Format: "[manufacturer]:[model]"
     string hardware_model = 1; 
+
+    // Optional: Only return software versions released after this timestamp.
+    // Useful for fetching 'new' or 'relevant' images for a fleet.
+    google.protobuf.Timestamp released_since = 2;
+
+    // Optional: A regex pattern to filter versions (e.g., "^7.5.*").
+    string version_filter_regex = 3;
+}
+// Metadata of the fetch software version response
+message SoftwareVersionMetadata {
+    // The canonical version string (e.g., "7.5.1")
+    string version = 1;
+
+    // The date the software image was officially released/built.
+    google.protobuf.Timestamp release_date = 2;
+    
+    // Optional: Indicates if the version is the current recommended/stable release.
+    bool is_recommended = 3;
 }
 
-// Response containing a list of known software version strings.
+// Response for fetching all known software versions for a specific hardware model.
 message FetchSoftwareVersionsResponse {
-
-    // List of valid software version strings 
-    // (e.g., "7.5.1", "XR-7.1.2") for the specified hardware model
-    repeated string software_versions = 1; 
+    // List of software versions and their associated metadata.
+    repeated SoftwareVersionMetadata software_versions = 1; 
 }
 
 


### PR DESCRIPTION
#### Description
The current lack of a unified standard for vendors to provide Platform Configuration Register (PCR) values—characterized by less secure delivery methods like Excel or JSON and disparate data formats—severely hampers the scalability and reliability of Google’s Attestation service for network infrastructure.

This fragmentation necessitates manual data entry and creates significant operational toil, ultimately slowing down the integrity verification process for network devices. To resolve this, we propose a standardized OpenConfig schema and protobuf-based framework that mandates vendors to deliver PCR values in a consistent, hex-standardized format via secure endpoints with every software release. By automating the ingestion of these measurements, the solution ensures a more reliable and efficient way to verify device trustworthiness across the network.